### PR TITLE
Fixes missing install_options and uninstall_options for puppetserver_gem provider

### DIFF
--- a/lib/puppet/provider/package/puppetserver_gem.rb
+++ b/lib/puppet/provider/package/puppetserver_gem.rb
@@ -9,7 +9,7 @@ Puppet::Type.type(:package).provide :puppetserver_gem, :parent => :gem do
     source is not present at all, the gem will be installed from the default gem
     repositories."
 
-  has_feature :versionable
+  has_feature :versionable, :install_options, :uninstall_options
 
   commands :puppetservercmd => "/opt/puppetlabs/bin/puppetserver" 
 


### PR DESCRIPTION
The install_options and uninstall_options are not passed to the provider because the feature declaration misses ':install_options' and ':uninstall_options'