### PR TITLE
Fix home environment variable

### DIFF
--- a/lib/puppet/provider/package/puppetserver_gem.rb
+++ b/lib/puppet/provider/package/puppetserver_gem.rb
@@ -17,7 +17,7 @@ Puppet::Type.type(:package).provide :puppetserver_gem, :parent => :gem do
 
   # the HOME variable is lost to the puppetserver script and needs to be
   # injected directly into the call to `execute()`
-  CMD_ENV = {:custom_environment => {:HOME => ENV['HOME']}}
+  CMD_ENV = {:custom_environment => {"HOME"=>ENV["HOME"]}}
 
 
   def self.gemlist(options)


### PR DESCRIPTION
I noticed that the gem commands did not set de HOME environment correctly. For example, the install on our offline machines, that should use Artifactory, with this settings set in $HOME/.gemrc were not used without this change.

This change will fix setting the HOME environment while executing a gem-cmmand. It has been copied from https://github.com/puppetlabs/puppet/blob/5.3.x/lib/puppet/provider/package/gem.rb.