### PR TITLE
(FM-7145) accelerate puppetserver_gem list

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,13 +1,25 @@
 ---
+Metrics/AbcSize:
+  Enabled: false
+Metrics/CyclomaticComplexity:
+  Enabled: false
+Metrics/PerceivedComplexity:
+  Enabled: false
 Metrics/LineLength:
   Max: 255
 Metrics/BlockLength:
-  Max: 48
+  Max: 144
 Metrics/MethodLength:
   Max: 32
 Style/GuardClause:
   Enabled: false
 Style/HashSyntax:
   Enabled: false
+Style/FormatString:
+  Enabled: false
+Style/FormatStringToken:
+  Enabled: false
 Style/SpecialGlobalVars:
+  Enabled: false
+Style/StringLiterals:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,13 @@
+---
+Metrics/LineLength:
+  Max: 255
+Metrics/BlockLength:
+  Max: 48
+Metrics/MethodLength:
+  Max: 32
+Style/GuardClause:
+  Enabled: false
+Style/HashSyntax:
+  Enabled: false
+Style/SpecialGlobalVars:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,67 @@
-source ENV['GEM_SOURCE'] || "https://rubygems.org"
+source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 
-group :development, :test do
-  gem 'rspec-core', '3.1.7',    :require => false
-  gem 'beaker-rspec',           :require => false
-  gem 'puppetlabs_spec_helper', :require => false
-  gem 'serverspec',             :require => false
+def location_for(place_or_version, fake_version = nil)
+  if place_or_version =~ %r{\A(git[:@][^#]*)#(.*)}
+    [fake_version, { git: Regexp.last_match(1), branch: Regexp.last_match(2), require: false }].compact
+  elsif place_or_version =~ %r{\Afile:\/\/(.*)}
+    ['>= 0', { path: File.expand_path(Regexp.last_match(1)), require: false }]
+  else
+    [place_or_version, { require: false }]
+  end
 end
+
+def gem_type(place_or_version)
+  if place_or_version =~ %r{\Agit[:@]}
+    :git
+  elsif !place_or_version.nil? && place_or_version.start_with?('file:')
+    :file
+  else
+    :gem
+  end
+end
+
+ruby_version_segments = Gem::Version.new(RUBY_VERSION.dup).segments
+minor_version = ruby_version_segments[0..1].join('.')
+
+group :development do
+  gem "fast_gettext", '1.1.0',                         require: false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.1.0')
+  gem "fast_gettext",                                  require: false if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.1.0')
+  gem "json_pure", '<= 2.0.1',                         require: false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.0.0')
+  gem "json", '= 1.8.1',                               require: false if Gem::Version.new(RUBY_VERSION.dup) == Gem::Version.new('2.1.9')
+  gem "json", '<= 2.0.4',                              require: false if Gem::Version.new(RUBY_VERSION.dup) == Gem::Version.new('2.4.4')
+  gem "puppet-module-posix-default-r#{minor_version}", require: false, platforms: [:ruby]
+  gem "puppet-module-posix-dev-r#{minor_version}",     require: false, platforms: [:ruby]
+  gem "puppet-strings", '~> 2.0.0',                    require: false
+end
+group :system_tests do
+  gem "puppet-module-posix-system-r#{minor_version}",                            require: false, platforms: [:ruby]
+  gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 3.13')
+  gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || '~> 0.1')
+  gem "beaker-pe",                                                               require: false
+  gem "beaker-hostgenerator"
+  gem "beaker-rspec"
+end
+
+puppet_version = ENV['PUPPET_GEM_VERSION']
+puppet_type = gem_type(puppet_version)
+
+gems = {}
+
+gems['puppet'] = location_for(puppet_version)
+
+gems.each do |gem_name, gem_params|
+  gem gem_name, *gem_params
+end
+
+# Evaluate Gemfile.local and ~/.gemfile if they exist
+extra_gemfiles = [
+  "#{__FILE__}.local",
+  File.join(Dir.home, '.gemfile'),
+]
+
+extra_gemfiles.each do |gemfile|
+  if File.file?(gemfile) && File.readable?(gemfile)
+    eval(File.read(gemfile), binding)
+  end
+end
+# vim: syntax=ruby

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,5 @@
+require 'puppetlabs_spec_helper/rake_tasks'
+require 'puppet-syntax/tasks/puppet-syntax'
+require 'puppet_blacksmith/rake_tasks' if Bundler.rubygems.find_name('puppet-blacksmith').any?
+
+PuppetLint.configuration.send('relative')

--- a/lib/puppet/provider/package/puppetserver_gem.rb
+++ b/lib/puppet/provider/package/puppetserver_gem.rb
@@ -1,5 +1,4 @@
 require 'facter'
-require 'hocon'
 require 'rubygems/commands/list_command'
 require 'puppet/provider/package'
 require 'stringio'
@@ -17,6 +16,7 @@ Puppet::Type.type(:package).provide :puppetserver_gem, :parent => :gem do
 
   has_feature :versionable, :install_options, :uninstall_options
 
+  confine :feature => :hocon
   commands :puppetservercmd => '/opt/puppetlabs/bin/puppetserver'
 
   # The HOME variable is lost to the puppetserver script 

--- a/lib/puppet/provider/package/puppetserver_gem.rb
+++ b/lib/puppet/provider/package/puppetserver_gem.rb
@@ -19,7 +19,7 @@ Puppet::Type.type(:package).provide :puppetserver_gem, :parent => :gem do
   confine :feature => :hocon
   commands :puppetservercmd => '/opt/puppetlabs/bin/puppetserver'
 
-  # The HOME variable is lost to the puppetserver script 
+  # The HOME variable is lost to the puppetserver script
   #  and needs to be injected directly into the call to `execute()`
   # When doing so, restore :failonfail and :combine to their defaults
   #  as per the documentation in lib/puppet/util/execution.rb

--- a/lib/puppet/provider/package/puppetserver_gem.rb
+++ b/lib/puppet/provider/package/puppetserver_gem.rb
@@ -127,27 +127,27 @@ Puppet::Type.type(:package).provide :puppetserver_gem, :parent => :gem do
   def install(useversion = true)
     command = [command(:puppetservercmd), 'gem', 'install']
     command += install_options if resource[:install_options]
-    command << '-v' << resource[:ensure] if (! resource[:ensure].is_a? Symbol) and useversion
+    command << '-v' << resource[:ensure] if (!resource[:ensure].is_a? Symbol) && useversion
 
     if source = resource[:source]
       begin
         uri = URI.parse(source)
       rescue => detail
-        self.fail Puppet::Error, _("Invalid source '%{uri}': %{detail}") % { uri: uri, detail: detail }, detail
+        fail Puppet::Error, _("Invalid source '%{uri}': %{detail}") % { uri: uri, detail: detail }, detail
       end
 
       case uri.scheme
-        when nil
-          # no URI scheme => interpret the source as a local file
-          command << source
-        when /file/i
-          command << uri.path
-        when 'puppet'
-          # we don't support puppet:// URLs (yet)
-          raise Puppet::Error.new(_("puppet:// URLs are not supported as gem sources"))
-        else
-          # interpret it as a gem repository
-          command << '--source' << "#{source}" << resource[:name]
+      when nil
+        # no URI scheme => interpret the source as a local file
+        command << source
+      when /file/i
+        command << uri.path
+      when 'puppet'
+        # we don't support puppet:// URLs (yet)
+        raise Puppet::Error.new(_('puppet:// URLs are not supported as gem sources'))
+      else
+        # interpret it as a gem repository
+        command << '--source' << source << resource[:name]
       end
     else
       command << '--no-rdoc' << '--no-ri' << resource[:name]
@@ -155,7 +155,7 @@ Puppet::Type.type(:package).provide :puppetserver_gem, :parent => :gem do
 
     output = execute(command, EXEC_OPTS)
     # Apparently, some gem versions don't exit non-0 on failure.
-    self.fail _("Could not install: %{output}") % { output: output.chomp } if output.include?('ERROR')
+    fail _("Could not install: %{output}") % { output: output.chomp } if output.include?('ERROR')
   end
 
   def uninstall
@@ -165,6 +165,6 @@ Puppet::Type.type(:package).provide :puppetserver_gem, :parent => :gem do
 
     output = execute(command, EXEC_OPTS)
     # Apparently, some gem versions don't exit non-0 on failure.
-    self.fail _("Could not uninstall: %{output}") % { output: output.chomp } if output.include?('ERROR')
+    fail _("Could not uninstall: %{output}") % { output: output.chomp } if output.include?('ERROR')
   end
 end

--- a/lib/puppet/provider/package/puppetserver_gem.rb
+++ b/lib/puppet/provider/package/puppetserver_gem.rb
@@ -1,4 +1,8 @@
+require 'facter'
+require 'hocon'
+require 'rubygems/commands/list_command'
 require 'puppet/provider/package'
+require 'stringio'
 require 'uri'
 
 # Ruby gems support.
@@ -13,53 +17,110 @@ Puppet::Type.type(:package).provide :puppetserver_gem, :parent => :gem do
 
   has_feature :versionable, :install_options, :uninstall_options
 
-  commands :puppetservercmd => "/opt/puppetlabs/bin/puppetserver"
+  commands :puppetservercmd => '/opt/puppetlabs/bin/puppetserver'
 
-  # the HOME variable is lost to the puppetserver script and needs to be
-  # injected directly into the call to `execute()`
-  CMD_ENV = {:custom_environment => {:HOME => ENV['HOME']}}
-
+  # The HOME variable is lost to the puppetserver script 
+  #  and needs to be injected directly into the call to `execute()`
+  # When doing so, restore :failonfail and :combine to their defaults
+  #  as per the documentation in lib/puppet/util/execution.rb
+  EXEC_OPTS = { :failonfail => true, :combine => true, :custom_environment => { :HOME => ENV['HOME'] } }
 
   def self.gemlist(options)
-    gem_list_command = [command(:puppetservercmd), "gem", "list"]
+    gem_list_command = [command(:puppetservercmd), 'gem', 'list']
 
     if options[:local]
-      gem_list_command << "--local"
+      gem_list_command << '--local'
     else
-      gem_list_command << "--remote"
-    end
-    if options[:source]
-      gem_list_command << "--source" << options[:source]
-    end
-    if name = options[:justme]
-      gem_list_command << "^" + name + "$"
+      gem_list_command << '--remote'
     end
 
-    begin
-      list = execute(gem_list_command, CMD_ENV).lines.
-          map {|set| gemsplit(set) }.
-          reject {|x| x.nil? }
-    rescue Puppet::ExecutionFailure => detail
-      raise Puppet::Error, "Could not list gems: #{detail}", detail.backtrace
+    if options[:source]
+      gem_list_command << "--source #{options[:source]}"
     end
+
+    if name = options[:justme]
+      gem_regex = '\A' + name + '\z'
+      gem_list_command << gem_regex
+    end
+
+    if options[:local]
+      list = execute_rubygems_list_command(gem_regex)
+    else
+      begin
+        list = execute(gem_list_command, EXEC_OPTS)
+      rescue Puppet::ExecutionFailure => detail
+        raise Puppet::Error, _("Could not list gems: %{detail}") % { detail: detail }, detail.backtrace
+      end
+    end
+
+    # When `/tmp` is mounted `noexec`, `puppetserver gem list` will output *** LOCAL GEMS ***
+    #  causing gemsplit to output: Warning: Could not match *** LOCAL GEMS ***
+    gem_list = list
+               .lines
+               .select { |x| x =~ /^(\S+)\s+\((.+)\)/ }
+               .map { |set| gemsplit(set) }
 
     if options[:justme]
-      return list.shift
+      return gem_list.shift
     else
-      return list
+      return gem_list
     end
   end
 
+  # The puppetserver gem cli commands are particularly slow as they start a JVM.
+  # Instead, for the often-executed list command, use the rubygems library from the puppet ruby,
+  #  setting the GEM_HOME and GEM_PATH to the values in the puppetserver configuration file.
+  # The rubygems library does not have access to java platform gems, for example: json (1.8.3 java),
+  #  but java platform gems should not be managed, by design.
+
+  def self.execute_rubygems_list_command(gem_regex)
+    pe_puppetserver_conf_file = '/etc/puppetlabs/puppetserver/conf.d/pe-puppet-server.conf'
+    os_puppetserver_conf_file = '/etc/puppetlabs/puppetserver/puppetserver.conf'
+    puppetserver_gem_home = '/opt/puppetlabs/server/data/puppetserver/jruby-gems'
+    puppetserver_gem_path = [puppetserver_gem_home, '/opt/puppetlabs/server/data/puppetserver/vendored-jruby-gems']
+    puppetserver_conf_file = Facter.value(:pe_server_version) ? pe_puppetserver_conf_file : os_puppetserver_conf_file
+    puppetserver_conf = Hocon.load(puppetserver_conf_file)
+    gem_env = {}
+    if puppetserver_conf.empty?
+      gem_env['GEM_HOME'] = puppetserver_gem_home
+      gem_env['GEM_PATH'] = puppetserver_gem_path.join(':')
+    else
+      gem_env['GEM_HOME'] = puppetserver_conf['jruby-puppet']['gem-home']
+      gem_env['GEM_PATH'] = puppetserver_conf['jruby-puppet']['gem-path'].join(':')
+    end
+    gem_env['GEM_SPEC_CACHE'] = "/tmp/#{$$}"
+    Gem.paths = gem_env
+
+    sio_inn = StringIO.new
+    sio_out = StringIO.new
+    sio_err = StringIO.new
+    stream_ui = Gem::StreamUI.new(sio_inn, sio_out, sio_err, false)
+    gem_list_cmd = Gem::Commands::ListCommand.new
+    gem_list_cmd.options[:domain] = :local
+    gem_list_cmd.options[:args] = [gem_regex] if gem_regex
+    gem_list_cmd.ui = stream_ui
+    gem_list_cmd.execute
+
+    # Remove default gems from the list, as the are the default gems from the puppet ruby:
+    #  /opt/puppetlabs/puppet/lib/ruby/gems/x.y.z/specifications/default
+    # There is no method exclude default gems from the local gem list, for example: psych (default: 2.2.2),
+    #  but default gems should not be managed, by design.
+    gem_list = sio_out.string.lines.reject { |gem| gem =~ / \(default\: / }
+    gem_list.join("\n")
+  ensure
+    Gem.clear_paths
+  end
+
   def install(useversion = true)
-    command = [command(:puppetservercmd), "gem", "install"]
+    command = [command(:puppetservercmd), 'gem', 'install']
     command += install_options if resource[:install_options]
-    command << "-v" << resource[:ensure] if (! resource[:ensure].is_a? Symbol) and useversion
+    command << '-v' << resource[:ensure] if (! resource[:ensure].is_a? Symbol) and useversion
 
     if source = resource[:source]
       begin
         uri = URI.parse(source)
       rescue => detail
-        self.fail Puppet::Error, "Invalid source '#{uri}': #{detail}", detail
+        self.fail Puppet::Error, _("Invalid source '%{uri}': %{detail}") % { uri: uri, detail: detail }, detail
       end
 
       case uri.scheme
@@ -70,25 +131,27 @@ Puppet::Type.type(:package).provide :puppetserver_gem, :parent => :gem do
           command << uri.path
         when 'puppet'
           # we don't support puppet:// URLs (yet)
-          raise Puppet::Error.new("puppet:// URLs are not supported as gem sources")
+          raise Puppet::Error.new(_("puppet:// URLs are not supported as gem sources"))
         else
           # interpret it as a gem repository
-          command << "--source" << "#{source}" << resource[:name]
+          command << '--source' << "#{source}" << resource[:name]
       end
     else
-      command << "--no-rdoc" << "--no-ri" << resource[:name]
+      command << '--no-rdoc' << '--no-ri' << resource[:name]
     end
 
-    output = execute(command, CMD_ENV)
-    # Apparently some stupid gem versions don't exit non-0 on failure
-    self.fail "Could not install: #{output.chomp}" if output.include?("ERROR")
+    output = execute(command, EXEC_OPTS)
+    # Apparently, some gem versions don't exit non-0 on failure.
+    self.fail _("Could not install: %{output}") % { output: output.chomp } if output.include?('ERROR')
   end
 
   def uninstall
-    command = [command(:puppetservercmd), "gem", "uninstall"]
-    command << "-x" << "-a" << resource[:name]
+    command = [command(:puppetservercmd), 'gem', 'uninstall']
+    command << '--executables' << '--all' << resource[:name]
+    command << uninstall_options if resource[:uninstall_options]
 
-    output = execute(command, CMD_ENV)
-    self.fail "Could not uninstall: #{output.chomp}" if output.include?("ERROR")
+    output = execute(command, EXEC_OPTS)
+    # Apparently, some gem versions don't exit non-0 on failure.
+    self.fail _("Could not uninstall: %{output}") % { output: output.chomp } if output.include?('ERROR')
   end
 end

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -1,13 +1,23 @@
+---
 HOSTS:
-  ubuntu-server-1404-x64:
+  masterblaster:
+    pe_dir: http://neptune.puppetlabs.lan/2017.3/ci-ready
+    pe_ver:
+    pe_upgrade_dir:
+    pe_upgrade_ver:
+    hypervisor: vmpooler
+#    hypervisor: none
+#    ip: xxx.delivery.puppetlabs.net
+    platform: el-7-x86_64
+    template: centos-7-x86_64
     roles:
-      - master
-      - database
-      - dashboard
-    platform: ubuntu-14.04-amd64
-    box : puppetlabs/ubuntu-14.04-64-nocm
-    box_url : https://vagrantcloud.com/puppetlabs/ubuntu-14.04-64-nocm
-    hypervisor : vagrant
+    - agent
+    - master
+    - database
+    - dashboard
 CONFIG:
-  log_level   : debug
-  type: git
+  nfs_server: none
+  consoleport: 443
+  pooling_api: http://vmpooler.delivery.puppetlabs.net/
+  ssh:
+    keys: "~/.ssh/id_rsa-acceptance"

--- a/spec/acceptance/puppetserver_gem_spec.rb
+++ b/spec/acceptance/puppetserver_gem_spec.rb
@@ -1,39 +1,46 @@
 require 'spec_helper_acceptance'
 
-describe 'installing a gem with the pe_puppetserver_gem provider' do
-  it 'should work with no errors' do
-    pp = <<-EOS
-      package { 'hocon':
-        ensure => present,
-        provider => puppetserver_gem,
-      }
-    EOS
+describe 'puppetserver_gem' do
+  let(:test_gem) { 'world_airports' }
 
-    # Run it twice to test for idempotency
-    apply_manifest(pp, :catch_failures => true)
-    expect(apply_manifest(pp, :catch_failures => true).exit_code).to be_zero
+  context 'installing a gem with the puppetserver_gem provider' do
+    it 'should execute without error' do
+      filename = '/tmp/puppetserver_gem_install.pp'
+      pp = <<-EOS
+        package { '#{test_gem}':
+          ensure   => present,
+          provider => puppetserver_gem,
+        }
+      EOS
+      create_remote_file(master, filename, pp)
+      on(master, puppet('apply', filename), acceptable_exit_codes: 0)
+    end
+    it 'should successfully install the gem' do
+      on(master, "puppetserver gem list | grep #{test_gem}", acceptable_exit_codes: 0)
+    end
   end
 
-  it 'should successfully install the desired gem' do
-    shell("/opt/puppetlabs/bin/puppetserver gem list | grep hocon", :acceptable_exit_codes => 0)
-  end
-end
-
-describe 'removing a gem with the pe_puppetserver_gem provider' do
-  it 'should work with no errors' do
-    pp = <<-EOS
-      package { 'hocon':
-        ensure => absent,
-        provider => puppetserver_gem,
-      }
-    EOS
-
-    # Run it twice to test for idempotency
-    apply_manifest(pp, :catch_failures => true)
-    expect(apply_manifest(pp, :catch_failures => true).exit_code).to be_zero
+  context 'listing gems with the puppetserver_gem provider' do
+    it 'should list the gem' do
+      result = on(master, puppet('resource', 'package', '--param provider', test_gem), acceptable_exit_codes: 0).stdout
+      expect(result).to match(/puppetserver_gem/)
+    end
   end
 
-  it 'should successfully remove the desired gem' do
-    shell("/opt/puppetlabs/bin/puppetserver gem list | grep hocon", :acceptable_exit_codes => 1)
+  context 'removing a gem with the puppetserver_gem provider' do
+    it 'should execute without error' do
+      filename = '/tmp/puppetserver_gem_uninstall.pp'
+      pp = <<-EOS
+        package { '#{test_gem}':
+          ensure   => absent,
+          provider => puppetserver_gem,
+        }
+      EOS
+      create_remote_file(master, filename, pp)
+      on(master, puppet('apply', filename), acceptable_exit_codes: 0)
+    end
+    it 'should successfully remove the gem' do
+      on(master, "puppetserver gem list | grep #{test_gem}", acceptable_exit_codes: 1)
+    end
   end
 end

--- a/spec/spec.opts
+++ b/spec/spec.opts
@@ -1,6 +1,0 @@
---format
-s
---colour
---loadby
-mtime
---backtrace

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,41 +1,25 @@
 require 'beaker-rspec/spec_helper'
 require 'beaker-rspec/helpers/serverspec'
+require 'beaker-task_helper'
+require 'beaker/puppet_install_helper'
+require 'beaker/module_install_helper'
 
-unless ENV['RS_PROVISION'] == 'no'
-#  if default.is_pe?; then
-#    install_pe;
-#  else
-     install_puppet;
-#  end
-  pp=<<-EOS
-  package { 'puppetserver': ensure => present, }
-  EOS
-  apply_manifest(pp)
-
-  hosts.each do |host|
-    if host['platform'] =~ /debian/
-      on host, 'echo \'export PATH=/var/lib/gems/1.8/bin/:${PATH}\' >> ~/.bashrc'
-      on host, "mkdir -p #{host['distmoduledir']}"
-    end
-  end
+if ENV['BEAKER_provision'] != 'no'
+  run_puppet_install_helper
+  install_module_on(hosts)
 end
 
 RSpec.configure do |c|
-  # Project root
   proj_root = File.expand_path(File.join(File.dirname(__FILE__), '..'))
-
-  # Readable test descriptions
   c.formatter = :documentation
-
-  # Configure all nodes in nodeset
   c.before :suite do
-    # Install module and dependencies
-    hosts.each do |host|
-      if host['platform'] !~ /windows/i
-        copy_root_module_to(host, :source => proj_root, :module_name => 'puppetserver_gem')
+    unless ENV['BEAKER_TESTMODE'] == 'local'
+      unless ENV['BEAKER_provision'] == 'no'
+
+      end
+      hosts.each do |host|
+
       end
     end
   end
-
-  c.treat_symbols_as_metadata_keys_with_true_values = true
 end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -15,10 +15,10 @@ RSpec.configure do |c|
   c.before :suite do
     unless ENV['BEAKER_TESTMODE'] == 'local'
       unless ENV['BEAKER_provision'] == 'no'
-
+        # intentionally blank
       end
       hosts.each do |host|
-
+        # intentionally blank
       end
     end
   end

--- a/tests/init.pp
+++ b/tests/init.pp
@@ -1,4 +1,4 @@
-package { 'hocon':
+package { 'world_airports':
   ensure   => present,
   provider => puppetserver_gem,
 }


### PR DESCRIPTION
The puppetserver gem cli commands are particularly slow as they start a JVM.
    
Instead, for the list command, use the rubygems library from the puppet ruby,
setting the GEM_HOME and GEM_PATH to the values in the puppetserver conf file.
    
The rubygems library does not have access to java platform gems,
but java platform gems should not be managed, by design.