### PR TITLE
(maint) - Make it explicit that this module is compatible with Puppet 5 and 6

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">=4.0.0 < 6.0.0"
+      "version_requirement": ">=4.0.0 < 7.0.0"
     }
   ],
   "dependencies": [

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">=4.0.0 < 5.0.0"
+      "version_requirement": ">=4.0.0 < 6.0.0"
     }
   ],
   "dependencies": [


### PR DESCRIPTION
Without this change Kafo-based installers need to be forced to load this module
with --skip-puppet-version-check. Other software that parses version
requirements in metadata.json may have similar issues.