### PR TITLE
(maint) remove unnecessary require

### DIFF
--- a/lib/puppet/provider/package/puppetserver_gem.rb
+++ b/lib/puppet/provider/package/puppetserver_gem.rb
@@ -1,6 +1,5 @@
 require 'facter'
 require 'rubygems/commands/list_command'
-require 'puppet/provider/package'
 require 'stringio'
 require 'uri'
 


### PR DESCRIPTION
PUP-10390 identified that requiring the parent's code is unnecessary.